### PR TITLE
Increase test coverage and fix race conditions

### DIFF
--- a/testdata/crawl/index.html
+++ b/testdata/crawl/index.html
@@ -5,6 +5,8 @@
   <ul>
     <li><a href="go_sucks.html">Why Go Sucks</a></li>
     <li><a href="rust_rules.html">Why Rust Rules</a></li>
+    <li><a href="invalid_links.html">Invalid links</a></li>
   </ul>
 </body>
 </html>
+

--- a/testdata/crawl/invalid_links.html
+++ b/testdata/crawl/invalid_links.html
@@ -1,0 +1,17 @@
+<html>
+
+  <head>
+    <title>Start page</title>
+  </head>
+
+  <body>
+    My latest interesting opinions:
+
+    <ul>
+      <li><a href="httq://invalid_scheme.html">Why Rust Rules</a></li>
+      <li><a href="http:// /">Why Rust Rules</a></li>
+    </ul>
+  </body>
+
+</html>
+


### PR DESCRIPTION
This PR introduces following changes:

- fixes race conditions
```shell
➜  weaver git:(test/test-coverage) go test -race
PASS
ok  	github.com/bitfield/weaver	2.429s
```
- increases test coverage

```shell
➜  weaver git:(test/test-coverage) ✗ go test -count=1 -cover -covermode=atomic -coverprofile=coverage.out
PASS
coverage: 57.4% of statements
ok  	github.com/bitfield/weaver	1.371s
```